### PR TITLE
Small compilation & runtime fixes detected on Ubuntu 24.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS := -Wall -Wextra -std=c11 -O2
 DEPFLAGS := -MMD -MP
 LIBS := libpng zlib
 CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBS))
-LDLIBS := $(shell $(PKG_CONFIG) --libs $(LIBS))
+LDLIBS := $(shell $(PKG_CONFIG) --libs $(LIBS)) -lm
 
 SRCS := bplopt.c bplconv.c image.c log.c
 OBJS := $(SRCS:.c=.o)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 PKG_CONFIG := pkg-config
 
-CFLAGS := -Wall -Wextra -std=c11
+CFLAGS := -Wall -Wextra -std=c11 -O2
 DEPFLAGS := -MMD -MP
 LIBS := libpng zlib
 CFLAGS += $(shell $(PKG_CONFIG) --cflags $(LIBS))

--- a/bplconv.c
+++ b/bplconv.c
@@ -3,6 +3,7 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "image.h"
 #include "log.h"

--- a/bplopt.c
+++ b/bplopt.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zlib.h>
+#include <stdint.h>
 
 #include "image.h"
 #include "log.h"

--- a/bplopt.c
+++ b/bplopt.c
@@ -48,6 +48,7 @@ uLongf compress_chunky(Image *image) {
       (unsigned char *)safe_malloc(compressed_size);
 
   compress(compressed_data, &compressed_size, image->data, chunky_size);
+  free(compressed_data);
   return compressed_size;
 }
 

--- a/bplopt.c
+++ b/bplopt.c
@@ -183,7 +183,7 @@ void find_optimal_palette_sa(Image *image, unsigned char *bpl_data,
 
 void print_palette(const Image *image) {
   // Need to invert order mappings
-  uint16_t *palette = safe_malloc(image->num_colors);
+  uint16_t *palette = safe_malloc(image->num_colors * sizeof(uint16_t));
   for (int i = 0; i < image->num_colors; i++) {
     palette[image->palette_order[i]] = i;
   }

--- a/image.c
+++ b/image.c
@@ -10,6 +10,10 @@
 #include "safe_mem.h"
 
 void free_image(Image *image) {
+  if (image->palette_order) {
+    free(image->palette_order);
+    image->palette_order = 0;
+  }
   if (image->palette) {
     free(image->palette);
     image->palette = 0;

--- a/log.h
+++ b/log.h
@@ -1,4 +1,4 @@
-int verbose;
+extern int verbose;
 
 void verbose_log(const char *format, ...);
 void error_log(const char *format, ...);


### PR DESCRIPTION
* Turn on standard -O2 optimization.
* Stop linker complaining about missing exp function.
* Add missing uint16_t definition.
* Fix crash due to buffer overflow.
* Fix two memory leaks detected by address sanitizer.
* Prevent linker error due to multiple symbol definitions.